### PR TITLE
Add online filtering for prompts based on the accuracy of the current…

### DIFF
--- a/examples/nlp/gpt/conf/gpt_reinforce_actor.yaml
+++ b/examples/nlp/gpt/conf/gpt_reinforce_actor.yaml
@@ -23,7 +23,9 @@ trainer:
     num_rollouts_per_prompt: 4
     prompt_rollouts_per_microbatch: 4
     val_prompt_rollouts_per_microbatch: 1
-
+    # Prompts are filtered from training whose accuracy is less than min or more than max threshold set below.
+    online_filtering_min_accuracy_threshold: 0.0
+    online_filtering_max_accuracy_threshold: 1.0
 
     # the sequence length to pad the rollout batch for training to
     # reduce fragmentation at the cost of using more

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_reinforce_math_actor.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_reinforce_math_actor.py
@@ -129,8 +129,9 @@ class MegatronGPTReinforceActorModel(NLPAdapterModelMixin, MegatronGPTModel, Ali
                 baseline = batch["baseline"]
                 tokens = batch["response_tokens"]
                 is_end = batch["is_end"]
-
-                is_end_mask = mask * is_end.view(-1, 1)
+                prompt_mask = batch["prompt_mask"]
+                
+                is_end_mask = mask * is_end.view(-1, 1) * prompt_mask.view(-1, 1)
 
                 curr_log_probs = from_parallel_logits_to_logprobs(
                     vocab_parallel_logits=parallel_logits, target=tokens, higher_stability=True

--- a/nemo_aligner/models/nlp/gpt/megatron_gpt_reinforce_math_actor.py
+++ b/nemo_aligner/models/nlp/gpt/megatron_gpt_reinforce_math_actor.py
@@ -131,7 +131,7 @@ class MegatronGPTReinforceActorModel(NLPAdapterModelMixin, MegatronGPTModel, Ali
                 is_end = batch["is_end"]
                 prompt_mask = batch["prompt_mask"]
                 
-                is_end_mask = mask * is_end.view(-1, 1) * prompt_mask.view(-1, 1)
+                is_end_mask = mask * is_end.view(-1, 1)
 
                 curr_log_probs = from_parallel_logits_to_logprobs(
                     vocab_parallel_logits=parallel_logits, target=tokens, higher_stability=True
@@ -146,7 +146,7 @@ class MegatronGPTReinforceActorModel(NLPAdapterModelMixin, MegatronGPTModel, Ali
                 reinforce_loss = -1 * curr_log_probs * (rewards.unsqueeze(-1) - baseline.unsqueeze(-1)) + self.cfg.reinforce.initial_policy_kl_penalty * calculate_kl_penalty_joschu2020(log_probs_policy=curr_log_probs, log_probs_reference=init_log_probs )#init_policy_kl
 
                 if is_end_mask.sum() > 0:
-                    loss = masked_mean(reinforce_loss, mask)
+                    loss = masked_mean(reinforce_loss, mask * prompt_mask.view(-1, 1))
                 else:
                     # hack to disable this update since there are no valid tokens
                     loss = reinforce_loss.view(-1)[0] * 0


### PR DESCRIPTION
This PR adds online filtering for prompts based on the accuracy of the current policy.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog 
- Please update the [CHANGELOG.md](/CHANGELOG.md) under next version with high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Make sure to also update the [NeMo Framework User Guide](https://docs.nvidia.com/nemo-framework/user-guide/latest/index.html) which contains the tutorials

# Checklist when contributing a new algorithm
- [ ] Does the trainer resume and restore model state all states?
- [ ] Does the trainer support all parallelism techniques(PP, TP, DP)?
- [ ] Does the trainer support `max_steps=-1` and `validation`?
- [ ] Does the trainer only call APIs defined in [alignable_interface.py](/nemo_aligner/models/alignable_interface.py)?
- [ ] Does the trainer have proper logging?

# Additional Information
* Related to # (issue)
