### PR TITLE
Added fast generation logging and baseline disable flag

### DIFF
--- a/examples/nlp/gpt/conf/gpt_reinforce_actor.yaml
+++ b/examples/nlp/gpt/conf/gpt_reinforce_actor.yaml
@@ -155,6 +155,7 @@ model:
       max_length: 3072 #${int_div:${model.encoder_seq_length}, 2}
       min_length: 1
 
+    disable_baseline: False
     trt_llm: ${trainer.reinforce.trt_llm}
 
   peft:


### PR DESCRIPTION
# What does this PR do ?

- Parallelizes generation logging across all ranks to reduce time to log from ~20 seconds to ~.2 seconds for 16 node jobs. Defaults generation logging on since this is now trivially fast.

- adds an option to remove baselining from REINFORCE, bringing the algorithm in-line with STaR. Though, experiments with this have shown it's worse than using a baseline. (default off)

- adds current logprob and initial logprob average logging to track any probability mass decay over training. 
